### PR TITLE
BUGFIX: GetPlayerRequest regex expression does not capture clients with negative ping

### DIFF
--- a/BytexDigital.BattlEye.Rcon/Commands/GetPlayersRequest.cs
+++ b/BytexDigital.BattlEye.Rcon/Commands/GetPlayersRequest.cs
@@ -25,7 +25,7 @@ namespace BytexDigital.BattlEye.Rcon.Commands
             // Will not work with user names such as 'Test User (Lobby)' because of how this player list is transmitted. No other alternative found so far.
             var matches = Regex.Matches(
                 content,
-                @"(\d+) *(\d*\.\d*\.\d*\.\d*):(\d*) *(\d+) *(\S{32})\((\S+)\) (.+?)(?=(?: \(Lobby\)$)|(?:$))( \(Lobby\))?",
+                @"(\d+) *(\d*\.\d*\.\d*\.\d*):(\d*) *(-?\d+) *(\S{32})\((\S+)\) (.+?)(?=(?: \(Lobby\)$)|(?:$))( \(Lobby\))?",
                 RegexOptions.Multiline);
             var players = new List<Player>();
 


### PR DESCRIPTION
### Situation
When a player client joins an Arma 3 server, it is possible for BattlEye to indicate a negative ping value (-1). The cause of this is unknown to me, but it is something that can happen regardless of what RCON client is used. See screenshot example:

![image](https://github.com/BytexDigital/BytexDigital.BattlEye.Rcon/assets/31687801/9a5ba122-bf73-4891-8c07-815ad96cf0ad)
_Application: battleWarden EX_

**The current regex expression does not handle this edgecase, causing that specific client to not get added to the result player list.**


### Changes
The fix to the above scenario is a small adjustment to the regex by adding an additional `-?` to the ping group, resulting in the following new expression: 
`(\d+) *(\d*\.\d*\.\d*\.\d*):(\d*) *(-?\d+) *(\S{32})\((\S+)\) (.+?)(?=(?: \(Lobby\)$)|(?:$))( \(Lobby\))?`

### Examples
**Old regex:**

![image](https://github.com/BytexDigital/BytexDigital.BattlEye.Rcon/assets/31687801/15446146-5c4a-4917-a1de-357fcfa72b3c)


**Updated regex:**

![image](https://github.com/BytexDigital/BytexDigital.BattlEye.Rcon/assets/31687801/1df4b4e4-d8df-45a9-b2a2-b8b0d23a5310)

_IP has been redacted from the images_